### PR TITLE
Add transform function

### DIFF
--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -7,11 +7,11 @@ import pandas as pd
 
 class SpectrogramsDataset(Dataset):
 
-    def __init__(self, spec_dir, features_path, target='genre', transform=None):
+    def __init__(self, spec_dir, features_path, transform=None, target='genre'):
         self.spec_dir = spec_dir
         self.features = pd.read_csv(features_path)
-        self.target = target
         self.transform = transform
+        self.target = target
 
         #encode labels
         if target=='genre':

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -4,6 +4,7 @@ from torch.utils.data import Dataset
 from PIL import Image
 import pandas as pd
 
+
 class SpectrogramsDataset(Dataset):
 
     def __init__(self, spec_dir, features_path, target='genre', transform=None):

--- a/utils/preprocessing.py
+++ b/utils/preprocessing.py
@@ -1,7 +1,9 @@
+from torchvision import transforms
 import matplotlib.pyplot as plt
 from PIL import Image
 import numpy as np
 import librosa
+
 
 def audio_to_spec(path_or_file):
 
@@ -23,3 +25,8 @@ def audio_to_spec(path_or_file):
     plt.close(fig) #to save memory
     with Image.frombuffer('RGBA', size, buffer) as spec:
         return spec.convert('RGB')
+
+
+transform = transforms.Compose([
+    transforms.Resize([224, 224]), #HxW
+    transforms.ToTensor()])


### PR DESCRIPTION
Adding `transform()` to `utils/preprocessing.py`. It's used to convert spectrograms to tensors (to pass them to the model). In this first version the transforms are the same ones that Marta used for her project. We can change them later (nothing will change from the POV of the web app). Usage examples:

* @EdoardoCortolezzis in web app (after getting `spec` with `utils.preprocessing.audio_to_spec()`):
```python
spec = transform(spec)
```

* @15Max during training:
```python
dataset = SpectrogramsDataset(spec_dir, features_path, transform=transform)
```