### PR TITLE
Adjust .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.pth filter=lfs diff=lfs merge=lfs -text
-danceability.pth !filter !diff !merge text
+danceability.pth !filter !diff !merge !text


### PR DESCRIPTION
Unsetting `text` attribute for `danceability.pth` in `.gitattributes` instead of forcing it to "true". Should be the preferable way to create a git LFS exception IMO because it should let git handle it in the default way (that maybe is the same as with `text` "true" but who knows)